### PR TITLE
Support for map styling and custom maker icons

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,13 @@ python:
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:
-  # - pip install -r requirements.txt
   - pip install coveralls
+  - pip install nose
+  - pip install -e .
 
 # command to run tests, e.g. python setup.py test
-script: 
-  - python setup.py test
-  - coverage run --source=motionless setup.py test
-after_success: coveralls
+script:
+  - nosetests --with-coverage --cover-package motionless
 
-sudo: false
+after_success:
+  - coveralls

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ motionless
 [![Coverage Status](https://coveralls.io/repos/ryancox/motionless/badge.svg?branch=master&service=github)](https://coveralls.io/github/ryancox/motionless?branch=master)
 
 
-motionless is a Python library that takes the pain out of generating [Google Static Map](http://code.google.com/apis/maps/documentation/staticmaps/) URLs. Three map types are supported. Each is illustrated below. For fully worked code see the examples directory for code that parses and visualizes both GeoRSS feeds and GPX files. 
+motionless is a Python library that takes the pain out of generating [Google Static Map](http://code.google.com/apis/maps/documentation/staticmaps/) URLs. Three map types are supported. Each is illustrated below. For fully worked code see the examples directory for code that parses and visualizes both GeoRSS feeds and GPX files.
 
 Code is licensed under Apache 2.0
 
@@ -14,7 +14,7 @@ For DecoratedMaps, paths are encoded if [gpolyencode](http://code.google.com/p/p
 
 If you have run into bugs, open a github issue. If you have questions, feel free to email me at ryan.a.cox@gmail.com
 
--ryan 
+-ryan
 @ryancox
 [www.asciiarmor.com](http://www.asciiarmor.com)
 
@@ -51,16 +51,30 @@ VisibleMaps show a map with no markers or paths, automatically sized and zoomed 
 DecoratedMap
 ============
 
-DecoratedMaps contain markers and/or paths. They are automatically sized and zoomed to make the specified elements visible.
+DecoratedMaps contain markers and/or paths. They are automatically sized and zoomed to make the specified elements visible. You can add a list of [style definitions](https://developers.google.com/maps/documentation/static-maps/intro#StyledMaps) to add custom styling to your map.
 
     from motionless import DecoratedMap
-    dmap = DecoratedMap()
+    road_styles = [{
+        'feature': 'road.highway',
+        'element': 'geomoetry',
+        'rules' {
+            'visibility': 'simplified',
+            'color': '#c280e9'
+        }
+    }, {
+        'feature': 'transit.line',
+        'rules': {
+            'visibility': 'simplified',
+            'color': '#bababa'
+        }
+    }]
+    dmap = DecoratedMap(style=road_styles)
     dmap.add_marker(AddressMarker('1 Infinite Loop, Cupertino, CA',label='A'))
     dmap.add_marker(AddressMarker('1600 Amphitheatre Parkway Mountain View, CA',label='G'))
     print dmap.generate_url()
 
 
-![Apple and Google](http://maps.google.com/maps/api/staticmap?maptype=roadmap&format=png&size=400x400&sensor=false&markers=|label:G|1600%20Amphitheatre%20Parkway%20Mountain%20View%2C%20CA&markers=|label:A|1%20Infinite%20Loop%2C%20Cupertino%2C%20CA)
+![Apple and Google](http://maps.google.com/maps/api/staticmap?maptype=roadmap&format=png&size=400x400&sensor=false&markers=|label:G|1600%20Amphitheatre%20Parkway%20Mountain%20View%2C%20CA&markers=|label:A|1%20Infinite%20Loop%2C%20Cupertino%2C%20CA&style=feature:road.highway%7Celement:geometry%7Cvisibility:simplified%7Ccolor:0xc280e9&style=feature:transit.line%7Cvisibility:simplified%7Ccolor:0xbababa)
 
 Produced from parsing GPX file. See [examples/munich.py](http://github.com/ryancox/motionless/blob/master/examples/munich.py)
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ DecoratedMaps contain markers and/or paths. They are automatically sized and zoo
     road_styles = [{
         'feature': 'road.highway',
         'element': 'geomoetry',
-        'rules' {
+        'rules': {
             'visibility': 'simplified',
             'color': '#c280e9'
         }

--- a/examples/demo.py
+++ b/examples/demo.py
@@ -1,4 +1,3 @@
-
 from motionless import AddressMarker, LatLonMarker,DecoratedMap, CenterMap, VisibleMap
 
 cmap = CenterMap(address='151 third st, san francisco, ca')
@@ -37,5 +36,5 @@ htmlPage = """
 html = open("demo.html","w")
 html.write(htmlPage)
 html.close()
-print "demo.html created"
+print("demo.html created")
 

--- a/examples/earthquakes.py
+++ b/examples/earthquakes.py
@@ -1,16 +1,15 @@
 from motionless import AddressMarker, LatLonMarker,DecoratedMap, CenterMap, VisibleMap
 import xml.sax
-
-import urllib2
+from six.moves.urllib import request
 
 class QuakeHandler(xml.sax.handler.ContentHandler):
     
     def __init__(self,gmap):
         self.content = []
         self.gmap = gmap
-        self.qname_point = (u'http://www.georss.org/georss',u'point')
-        self.qname_title = (u'http://www.w3.org/2005/Atom', u'title')
-        self.qname_entry = (u'http://www.w3.org/2005/Atom', u'entry')
+        self.qname_point = ('http://www.georss.org/georss','point')
+        self.qname_title = ('http://www.w3.org/2005/Atom', 'title')
+        self.qname_entry = ('http://www.w3.org/2005/Atom', 'entry')
 
 
     def startElementNS(self, qname, name, attrs):
@@ -50,7 +49,7 @@ parser = xml.sax.make_parser()
 parser.setContentHandler(QuakeHandler(quake))
 parser.setFeature(xml.sax.handler.feature_namespaces, 1)
 
-opener = urllib2.urlopen( 'http://earthquake.usgs.gov/earthquakes/catalogs/1day-M2.5.xml')
+opener = request.urlopen( 'http://earthquake.usgs.gov/earthquakes/catalogs/1day-M2.5.xml')
 parser.feed(opener.read())
 
 htmlPage = """
@@ -69,4 +68,4 @@ htmlPage = """
 html = open("earthquakes.html","w")
 html.write(htmlPage)
 html.close()
-print "earthquakes.html file created"
+print("earthquakes.html file created")

--- a/examples/gpolyencode.py
+++ b/examples/gpolyencode.py
@@ -1,8 +1,5 @@
 import math
-try:
-    from cStringIO import StringIO
-except:
-    from StringIO import StringIO
+from six import StringIO
 
 class GPolyEncoder(object):
     def __init__(self, num_levels=18, zoom_factor=2, threshold=0.00001, force_endpoints=True):

--- a/examples/munich.py
+++ b/examples/munich.py
@@ -10,7 +10,7 @@ class GPXHandler(xml.sax.handler.ContentHandler):
 
     def startElement(self, name, attrs):
         if name == 'trkpt': 
-	    self.gmap.add_path_latlon(attrs['lat'],attrs['lon'])
+            self.gmap.add_path_latlon(attrs['lat'],attrs['lon'])
             self.prev = (attrs['lat'],attrs['lon'])
             if self.first:
                 self.first = False
@@ -34,12 +34,12 @@ htmlPage = """
 <p/>
 <img src="%s"/>
 </body>
-</html>	
+</html>
 """ % munich.generate_url()
 
 
 html = open("munich.html","w")
 html.write(htmlPage)
 html.close()
-print "munich.html file created"
+print("munich.html file created")
 

--- a/motionless.py
+++ b/motionless.py
@@ -71,7 +71,7 @@ class Marker(object):
         self.size = size
         self.color = color
         self.label = label
-        self.icon_url = quote(icon_url)
+        self.icon_url = quote(icon_url) if icon_url else None
 
     def check_icon_url(self, url):
         result = urlparse(url)
@@ -100,7 +100,7 @@ class Map(object):
     MAX_X = 640
     MAX_Y = 640
     ZOOM_RANGE = list(range(1, 21))
-    SCALE_RANGE = list(range(1,5))
+    SCALE_RANGE = list(range(1, 5))
 
     def __init__(self, size_x, size_y, maptype, zoom=None, scale=1, key=None, language='en', style=None):
         self.base_url = 'https://maps.google.com/maps/api/staticmap?'

--- a/motionless.py
+++ b/motionless.py
@@ -1,4 +1,4 @@
-from urllib import quote
+from six.moves.urllib.parse import quote
 import re
 
 """
@@ -57,7 +57,7 @@ class Marker(object):
             raise ValueError(
                 "[%s] is not a valid marker size. Valid sizes include %s" %
                 (size, Marker.SIZES))
-        if label and (len(label) <> 1 or not label in Marker.LABELS):
+        if label and (len(label) != 1 or not label in Marker.LABELS):
             raise ValueError(
                 "[%s] is not a valid label. Valid labels are a single character 'A'..'Z' or '0'..'9'" % label)
         if color and color not in Color.COLORS:
@@ -90,8 +90,8 @@ class Map(object):
     FORMATS = ['png', 'png8', 'png32', 'gif', 'jpg', 'jpg-baseline']
     MAX_X = 640
     MAX_Y = 640
-    ZOOM_RANGE = range(1, 21)
-    SCALE_RANGE = range(1,5)
+    ZOOM_RANGE = list(range(1, 21))
+    SCALE_RANGE = list(range(1,5))
 
     def __init__(self, size_x, size_y, maptype, zoom=None, scale=1, key=None, language='en'):
         self.base_url = 'https://maps.google.com/maps/api/staticmap?'
@@ -249,7 +249,7 @@ class DecoratedMap(Map):
             raise ValueError(
                 "At least two path elements required if region is enabled")
 
-        if self.region and self.path[0] <> self.path[-1]:
+        if self.region and self.path[0] != self.path[-1]:
             raise ValueError(
                 "If region enabled, first and last path entry must be identical")
 

--- a/tests/test_motionless.py
+++ b/tests/test_motionless.py
@@ -4,7 +4,8 @@ Unit tests for pypvwatts.
 
 """
 import unittest
-from motionless import CenterMap
+
+from motionless import CenterMap, DecoratedMap, LatLonMarker
 
 
 class Test(unittest.TestCase):
@@ -20,10 +21,28 @@ class Test(unittest.TestCase):
     def test_create_map_with_address(self):
         """Checks the correct url generated with an address"""
         center_map = CenterMap(address=self.address)
-        # cmap1 = CenterMap(lat=48.858278,lon=2.294489,maptype='satellite')
+
         self.assertEqual(
             center_map.generate_url(),
             'https://maps.google.com/maps/api/staticmap?maptype=roadmap&format=png&scale=1&center=151%20third%20st%2C%20san%20francisco%2C%20ca&zoom=17&size=400x400&sensor=false&language=en')
+
+    def test_create_marker_map_with_styles(self):
+        """Check correct url generated with markers + styles"""
+        styles = [{
+            'feature': 'road.highway',
+            'element': 'geomoetry',
+            'rules': {
+                'color': '#c280e9'
+            }
+        }]
+        decorated_map = DecoratedMap(style=styles)
+        decorated_map.add_marker(LatLonMarker('37.422782', '-122.085099',
+                                              label='G'))
+        self.assertEqual(
+            decorated_map.generate_url(),
+            'https://maps.google.com/maps/api/staticmap?maptype=roadmap&format=png&scale=1&size=400x400&sensor=false&language=en&markers=|label:G|37.422782,-122.085099&style=feature:road.highway|element:geomoetry|color:0xc280e9|'
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Hi, I've been using motionless for a project and needed a few new features so I thought I might as well add them in. The two I needed were:
- [custom markers icons](
https://developers.google.com/maps/documentation/static-maps/intro#CustomIcons)
- [styling rules for maps] (https://developers.google.com/maps/documentation/static-maps/intro#StyledMaps)

I also added a few lines to the README to document how to create definitions for the styling rules.
I forked from @fmaussion's pull request because the project I needed this for was python3. I've ran into no problems using that branch. 