### PR TITLE
Module version number should live in the module itself, not setup.py

### DIFF
--- a/motionless.py
+++ b/motionless.py
@@ -36,7 +36,7 @@ from gpolyencode import GPolyEncoder
 
 
 __author__ = "Ryan Cox <ryan.a.cox@gmail.com>"
-__version__ = "1.0"
+__version__ = "1.3.1"
 
 
 class Color(object):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python
 
-__author__ = 'Ryan Cox <ryan.a.cox@gmail.com>'
-__version__ = '1.3.1'
+from motionless import __version__
 
 # Distutils version
 METADATA = dict(


### PR DESCRIPTION
This tiny PR moves the module's canonical `__version__` number out of `setup.py` and into the `motionless.py` module itself. This removes the duplication (there were two `__version__` and they were inconsistent) and places it where it can be queried at runtime by other software.