### PR TITLE
Add `simplify_threshold_meters` param to `DecoratedMap()` constructor...

### DIFF
--- a/motionless.py
+++ b/motionless.py
@@ -248,9 +248,12 @@ class DecoratedMap(Map):
         self.pathweight = pathweight
         self.pathcolor = pathcolor
         self.region = region
-        self.simplify_threshold = simplify_threshold_meters / DecoratedMap.METERS_PER_DEGREE
         self.path = []
         self.contains_addresses = False
+        if simplify_threshold_meters is None:
+            self.simplify_threshold = 0
+        else:
+            self.simplify_threshold = simplify_threshold_meters / DecoratedMap.METERS_PER_DEGREE
         if lat and lon:
             self.center = "%s,%s" % (lat, lon)
         else:

--- a/motionless.py
+++ b/motionless.py
@@ -235,9 +235,12 @@ class VisibleMap(Map):
 
 class DecoratedMap(Map):
 
+    METERS_PER_DEGREE = 111111.0
+
     def __init__(self, lat=None, lon=None, zoom=None, size_x=400, size_y=400,
                  maptype='roadmap', scale=1, region=False, fillcolor='green',
-                 pathweight=None, pathcolor=None, key=None, style=None):
+                 pathweight=None, pathcolor=None, key=None, style=None,
+                 simplify_threshold_meters=1.11111):
         Map.__init__(self, size_x=size_x, size_y=size_y, maptype=maptype,
                      zoom=zoom, scale=scale, key=key, style=style)
         self.markers = []
@@ -245,6 +248,7 @@ class DecoratedMap(Map):
         self.pathweight = pathweight
         self.pathcolor = pathcolor
         self.region = region
+        self.simplify_threshold = simplify_threshold_meters / DecoratedMap.METERS_PER_DEGREE
         self.path = []
         self.contains_addresses = False
         if lat and lon:
@@ -315,7 +319,7 @@ class DecoratedMap(Map):
         return "&".join(ret)
 
     def _polyencode(self):
-        encoder = GPolyEncoder()
+        encoder = GPolyEncoder(threshold=self.simplify_threshold)
         points = []
         for point in self.path:
             tokens = point.split(',')


### PR DESCRIPTION
This allows users to specify the RDP path simplification threshold value expressed in *approximate meters*. 

This value is accurate for X and Y dimensions at the equator, but is inflated in the X dimension with increasing latitude. The same problem anomaly applies to degrees, as the "size" of a degree longitude also decreases with increasing latitude.

The default value of ~1.1m corresponds to the historic default value as used within GPolyEncode of 0.00001 degrees.

Setting `simplify_threshold_meters=None` will disable path simplification.