### PR TITLE
Drop py 2.6 tests on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ language: python
 
 python:
   - "2.7"
-  - "2.6"
   - "3.4"
   - "3.5"
   - "pypy"


### PR DESCRIPTION
Currently the tests aren't working and I don't think we should care too much: most OS projects dropped py2.6 support a while ago.

This PR drops the tests on py2.6