### PR TITLE
Fix URL query-string encoding

### DIFF
--- a/motionless.py
+++ b/motionless.py
@@ -343,8 +343,7 @@ class DecoratedMap(Map):
 
     def generate_url(self):
         self.check_parameters()
-        url = "%s%smaptype=%s&format=%s&scale=%s&size=%sx%s&sensor=%s&language=%s" % (
-            self.base_url,
+        query = "%smaptype=%s&format=%s&scale=%s&size=%sx%s&sensor=%s&language=%s" % (
             self._get_key(),
             self.maptype,
             self.format,
@@ -355,36 +354,38 @@ class DecoratedMap(Map):
             self.language)
 
         if self.center:
-            url = "%s&center=%s" % (url, self.center)
+            query = "%s&center=%s" % (query, self.center)
 
         if self.zoom:
-            url = "%s&zoom=%s" % (url, self.zoom)
+            query = "%s&zoom=%s" % (query, self.zoom)
 
         if len(self.markers) > 0:
-            url = "%s&%s" % (url, self._generate_markers())
+            query = "%s&%s" % (query, self._generate_markers())
 
         if len(self.path) > 0:
-            url = "%s&path=" % url
+            query = "%s&path=" % query
 
             if self.pathcolor:
-                url = "%scolor:%s|" % (url, self.pathcolor)
+                query = "%scolor:%s|" % (query, self.pathcolor)
 
             if self.pathweight:
-                url = "%sweight:%s|" % (url, self.pathweight)
+                query = "%sweight:%s|" % (query, self.pathweight)
 
             if self.region:
-                url = "%sfillcolor:%s|" % (url, self.fillcolor)
+                query = "%sfillcolor:%s|" % (query, self.fillcolor)
 
-            url = "%senc:%s" % (url, quote(self._polyencode()))
+            query = "%senc:%s" % (query, quote(self._polyencode()))
 
         if self.style:
             for style_map in self.style:
-                url = "%s&style=feature:%s|element:%s|" % (
-                    url,
+                query = "%s&style=feature:%s|element:%s|" % (
+                    query,
                     (style_map['feature'] if 'feature' in style_map else 'all'),
                     (style_map['element'] if 'element' in style_map else 'all'))
                 for prop, rule in style_map['rules'].items():
-                    url = "%s%s:%s|" % (url, prop, str(rule).replace('#', '0x'))
+                    query = "%s%s:%s|" % (query, prop, str(rule).replace('#', '0x'))
+
+        url = self.base_url + quote(query, safe='/&=')
 
         self._check_url(url)
 

--- a/motionless.py
+++ b/motionless.py
@@ -186,8 +186,7 @@ class CenterMap(Map):
 
     def generate_url(self):
         self.check_parameters()
-        url = "%s%smaptype=%s&format=%s&scale=%s&center=%s&zoom=%s&size=%sx%s&sensor=%s&language=%s" % (
-            self.base_url,
+        query = "%smaptype=%s&format=%s&scale=%s&center=%s&zoom=%s&size=%sx%s&sensor=%s&language=%s" % (
             self._get_key(),
             self.maptype,
             self.format,
@@ -198,6 +197,8 @@ class CenterMap(Map):
             self.size_y,
             self._get_sensor(),
             self.language)
+
+        url = self.base_url + quote(query, safe='/&=%')
 
         self._check_url(url)
         return url
@@ -217,8 +218,7 @@ class VisibleMap(Map):
 
     def generate_url(self):
         self.check_parameters()
-        url = "%s%smaptype=%s&format=%s&scale=%s&size=%sx%s&sensor=%s&visible=%s&language=%s" % (
-            self.base_url,
+        query = "%smaptype=%s&format=%s&scale=%s&size=%sx%s&sensor=%s&visible=%s&language=%s" % (
             self._get_key(),
             self.maptype,
             self.format,
@@ -229,7 +229,10 @@ class VisibleMap(Map):
             "|".join(self.locations),
             self.language)
 
+        url = self.base_url + quote(query, safe='/&=%')
+
         self._check_url(url)
+
         return url
 
 
@@ -385,7 +388,7 @@ class DecoratedMap(Map):
                 for prop, rule in style_map['rules'].items():
                     query = "%s%s:%s|" % (query, prop, str(rule).replace('#', '0x'))
 
-        url = self.base_url + quote(query, safe='/&=')
+        url = self.base_url + quote(query, safe='/&=%')
 
         self._check_url(url)
 

--- a/motionless.py
+++ b/motionless.py
@@ -103,7 +103,7 @@ class Map(object):
     SCALE_RANGE = list(range(1, 5))
 
     def __init__(self, size_x, size_y, maptype, zoom=None, scale=1, key=None, language='en', style=None):
-        self.base_url = 'https://maps.google.com/maps/api/staticmap?'
+        self.base_url = 'https://maps.googleapis.com/maps/api/staticmap?'
         self.size_x = size_x
         self.size_y = size_y
         self.sensor = False

--- a/tests/test_motionless.py
+++ b/tests/test_motionless.py
@@ -24,8 +24,8 @@ class TestMotionless(unittest.TestCase):
 
         self.assertEqual(
             cmap_sat.generate_url(),
-            'https://maps.google.com/maps/api/staticmap?maptype=satellite&f'
-            'ormat=png&scale=1&center=48.858278,2.294489&zoom=17&'
+            'https://maps.googleapis.com/maps/api/staticmap?maptype=satellite&'
+            'format=png&scale=1&center=48.858278,2.294489&zoom=17&'
             'size=400x400&sensor=false&language=en')
 
     def test_visible(self):
@@ -36,7 +36,7 @@ class TestMotionless(unittest.TestCase):
 
         self.assertEqual(
             vmap.generate_url(),
-            'https://maps.google.com/maps/api/staticmap?maptype=terrain&'
+            'https://maps.googleapis.com/maps/api/staticmap?maptype=terrain&'
             'format=png&scale=1&size=400x400&sensor=false&'
             'visible=Sugarbowl%2C%20Truckee%2C%20CA|Tahoe%20City%2C%20CA&'
             'language=en')
@@ -47,7 +47,7 @@ class TestMotionless(unittest.TestCase):
 
         self.assertEqual(
             center_map.generate_url(),
-            'https://maps.google.com/maps/api/staticmap?maptype=roadmap&'
+            'https://maps.googleapis.com/maps/api/staticmap?maptype=roadmap&'
             'format=png&scale=1&center=151%20third%20st%2C%20san%20francisco'
             '%2C%20ca&zoom=17&size=400x400&sensor=false&language=en')
 
@@ -76,7 +76,7 @@ class TestMotionless(unittest.TestCase):
                                               label='G'))
         self.assertEqual(
             decorated_map.generate_url(),
-            'https://maps.google.com/maps/api/staticmap?maptype=roadmap&'
+            'https://maps.googleapis.com/maps/api/staticmap?maptype=roadmap&'
             'format=png&scale=1&size=400x400&sensor=false&language=en&'
             'markers=|label:G|37.422782,-122.085099&'
             'style=feature:road.highway|element:geomoetry|color:0xc280e9|'

--- a/tests/test_motionless.py
+++ b/tests/test_motionless.py
@@ -78,8 +78,9 @@ class TestMotionless(unittest.TestCase):
             decorated_map.generate_url(),
             'https://maps.googleapis.com/maps/api/staticmap?maptype=roadmap&'
             'format=png&scale=1&size=400x400&sensor=false&language=en&'
-            'markers=|label:G|37.422782,-122.085099&'
-            'style=feature:road.highway|element:geomoetry|color:0xc280e9|'
+            'markers=%7Clabel%3AG%7C37.422782%2C-122.085099&'
+            'style=feature%3Aroad.highway%7Celement%3Ageomoetry%7C'
+            'color%3A0xc280e9%7C'
         )
 
     def test_demos(self):

--- a/tests/test_motionless.py
+++ b/tests/test_motionless.py
@@ -24,8 +24,8 @@ class TestMotionless(unittest.TestCase):
 
         self.assertEqual(
             cmap_sat.generate_url(),
-            'https://maps.googleapis.com/maps/api/staticmap?maptype=satellite&'
-            'format=png&scale=1&center=48.858278,2.294489&zoom=17&'
+            'https://maps.googleapis.com/maps/api/staticmap?maptype=satellite&f'
+            'ormat=png&scale=1&center=48.858278%2C2.294489&zoom=17&'
             'size=400x400&sensor=false&language=en')
 
     def test_visible(self):
@@ -38,7 +38,7 @@ class TestMotionless(unittest.TestCase):
             vmap.generate_url(),
             'https://maps.googleapis.com/maps/api/staticmap?maptype=terrain&'
             'format=png&scale=1&size=400x400&sensor=false&'
-            'visible=Sugarbowl%2C%20Truckee%2C%20CA|Tahoe%20City%2C%20CA&'
+            'visible=Sugarbowl%2C%20Truckee%2C%20CA%7CTahoe%20City%2C%20CA&'
             'language=en')
 
     def test_create_map_with_address(self):


### PR DESCRIPTION
Special characters in query string such as `|` will be encoded by image proxies such as Gmail's GoogleUserContent and will break any signed staticmap URL. Doing the encoding early right in motionless avoids the pain of requiring the caller to parse the URL and encode its query-string before signing it.